### PR TITLE
Fixed: Avoid error when app does not have user authentication

### DIFF
--- a/src/Carbonated.php
+++ b/src/Carbonated.php
@@ -56,8 +56,7 @@ trait Carbonated {
         }
 
         // If not, check for timezone in authenticated User class.
-        // TODO: Avoid error when app does not have user authentication?
-        elseif (\Auth::check() && method_exists(config('auth.model'), 'getTimezone')) {
+        elseif (class_exists(\Auth::class) && \Auth::check() && method_exists(config('auth.model'), 'getTimezone')) {
             return \Auth::user()->getTimezone();
         }
 


### PR DESCRIPTION
Just a small check whether the user has the Auth class in their project
or not.